### PR TITLE
provide default scc values 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,8 @@ setup:
 ## Run lint with helm linting tool
 lint: tool
 	helm lint stable/$(CHART_NAME)
+
+.PHONY: build
+## Packages helm-api folder into chart archive
+build: setup
+	helm package stable/$(CHART_NAME)

--- a/stable/kui-web-terminal/templates/kui-scc.yaml
+++ b/stable/kui-web-terminal/templates/kui-scc.yaml
@@ -5,9 +5,10 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
-allowedCapabilities: null
+allowedCapabilities: []
 apiVersion: security.openshift.io/v1
-defaultAddCapabilities: null
+defaultAddCapabilities: []
+priority: 0
 fsGroup:
   type: RunAsAny
 kind: SecurityContextConstraints


### PR DESCRIPTION
Reference: https://github.com/open-cluster-management/backlog/issues/3349

Set default values for 
- allowedCapabilities, 
- defaultAddCapabilities
- priority 
to address validation  errors seen on OCP 4.3 installations.