### PR TITLE
3966 change deprecated ingress kind

### DIFF
--- a/stable/kui-web-terminal/templates/kui-ingress.yaml
+++ b/stable/kui-web-terminal/templates/kui-ingress.yaml
@@ -8,7 +8,7 @@
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ###############################################################################
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 
 metadata:


### PR DESCRIPTION
Change `kui-web-terminal-chart/stable/kui-web-terminal/templatese/kui-ingress.yaml` to use the `networking.k8s.io/v1beta1` apiVersion supported since k8s 1.14 and no longer the deprecated `extensions/v1beta1`.  (This was found working on the `release-2.0` branch changes needed for https://github.com/open-cluster-management/backlog/issues/3966