### PR TITLE
allow automount of service account token

### DIFF
--- a/stable/kui-web-terminal/templates/kui-deployment.yaml
+++ b/stable/kui-web-terminal/templates/kui-deployment.yaml
@@ -64,7 +64,6 @@ spec:
       nodeSelector:
       {{ toYaml . | indent 8 }}
       {{- end }} 
-      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 60
       containers:
       - name: {{ .Values.proxy.name }}


### PR DESCRIPTION
For https://github.com/open-cluster-management/backlog/issues/7694 to make the service account token available so Visual Web Terminal can call k8s APIs.